### PR TITLE
Stop unregister_self from marking objects unregistered incorrectly

### DIFF
--- a/src/lib/pytch/project.js
+++ b/src/lib/pytch/project.js
@@ -310,8 +310,10 @@ var $builtinmodule = function (name) {
             // both try to unregister the same sprite in the same
             // scheduler-time-slice.
             //
-            if (instance_idx > 0)
+
+            if (instance_idx > 0) 
                 this.instances.splice(instance_idx, 1);
+	    return instance_idx > 0;
         }
 
         create_threads_for_green_flag() {
@@ -489,9 +491,9 @@ var $builtinmodule = function (name) {
 
         unregister_self() {
             let actor = this.actor;
-            actor.unregister_instance(this);
-
-            this.py_object_is_registered = false;
+            
+	    this.py_object_is_registered = actor.unregister_instance(this);
+	    
         }
 
         get info_label() {


### PR DESCRIPTION
unregister_self was marking the current object as unregistered even if
unregister_instance had decided not to unregister it. This means that
doing delete_this_clone(self) would effectively delete the 'original'
instance-0 of a Sprite.

This change makes unregister_instance return a boolean indicating whether the unregistration happened, which unregister_self respects.