### PR TITLE
Handle bad args for key_pressed() and when_key_pressed()

### DIFF
--- a/src/lib/pytch/hat_blocks.py
+++ b/src/lib/pytch/hat_blocks.py
@@ -1,3 +1,5 @@
+from .syscalls import _assert_keyname_valid
+
 def _append_handler(fun, handler_type, handler_data=None):
     if not hasattr(fun, '_pytch_handler_for'):
         fun._pytch_handler_for = []
@@ -27,6 +29,7 @@ class when_I_receive:
 class when_key_pressed:
     "(KEY) Run your method when the user presses KEY"
     def __init__(self, keyname):
+        _assert_keyname_valid(keyname)
         self.keyname = keyname
 
     def __call__(self, fun):

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -31,7 +31,7 @@ var $builtinmodule = function (name) {
             throw new Sk.builtin.ValueError(
                 "keyname must be a string"
             );
-        jsKeyname = py_keyname.v;
+        const jsKeyname = py_keyname.v;
         if (isValidKeyname(jsKeyname))
             return;
         if (!jsKeyname)
@@ -44,7 +44,7 @@ var $builtinmodule = function (name) {
                 + `if you meant the spacebar, use " " (that's a string `
                 + `consisting of a single space character)`
             );
-        maybe_suggestion = suggestedKeyname(jsKeyname)
+        const maybe_suggestion = suggestedKeyname(jsKeyname)
         if (maybe_suggestion != null)
             throw new Sk.builtin.ValueError(
                 `keyname must be a valid key. `

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -16,7 +16,7 @@ var $builtinmodule = function (name) {
     });
 
     const isValidKeyname = (keyname) => validKeys.includes(keyname)
-
+    
     function suggestedKeyname(invalidKeyname) {
         //Remove symbols and capital letters to suggest a keyname
         //Eg "Arrowleft", "arrowLeft" or "Arrow-Left" -> "ArrowLeft"
@@ -325,7 +325,8 @@ var $builtinmodule = function (name) {
 
     mod.key_pressed = skulpt_function(
         (py_keyname) => {
-            let js_keyname = Sk.ffi.remapToJs(py_keyname);
+            assertPyKeynameValid(py_keyname)
+            let js_keyname = py_keyname.v;
             return (Sk.pytch.keyboard.key_is_pressed(js_keyname)
                     ? Sk.builtin.bool.true$
                     : Sk.builtin.bool.false$);

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -8,12 +8,7 @@ var $builtinmodule = function (name) {
     "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
     " ", "ArrowLeft", "ArrowDown", "ArrowUp", "ArrowRight"];
 
-    const map = {};
-
-    validKeys.forEach(validKey => {
-        if (validKey !== " ")
-            map[validKey.toLowerCase()] = validKey;
-    });
+    const validKeyFromLowerCaseLut = new Map(validKeys.map(key => [key.toLowerCase(), key]));
 
     const isValidKeyname = (keyname) => validKeys.includes(keyname)
     
@@ -22,7 +17,7 @@ var $builtinmodule = function (name) {
         //Eg "Arrowleft", "arrowLeft" or "Arrow-Left" -> "ArrowLeft"
         const invalidKeynameLower = invalidKeyname.toLowerCase();
         var invalidKeynameCleaned = invalidKeynameLower.trim().replace(/[^a-z0-9]/g, "");
-        const suggested_key = map[invalidKeynameCleaned];
+        const suggested_key = validKeyFromLowerCaseLut.get(invalidKeynameCleaned);
         return suggested_key || null;
     }
 

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -26,6 +26,39 @@ var $builtinmodule = function (name) {
         return suggested_key || null;
     }
 
+    function assertPyKeynameValid(py_keyname) {
+        if (!Sk.builtin.checkString(py_keyname))
+            throw new Sk.builtin.ValueError(
+                "keyname must be a string"
+            );
+        jsKeyname = py_keyname.v;
+        if (isValidKeyname(jsKeyname))
+            return;
+        if (!jsKeyname)
+            throw new Sk.builtin.ValueError(
+                `keyname must not be an empty string.`
+            );
+        if (!jsKeyname.trim())
+            throw new Sk.builtin.ValueError(
+                `keyname must be a valid key; `
+                + `if you meant the spacebar, use " " (that's a string `
+                + `consisting of a single space character)`
+            );
+        maybe_suggestion = suggestedKeyname(jsKeyname)
+        if (maybe_suggestion != null)
+            throw new Sk.builtin.ValueError(
+                `keyname must be a valid key. `
+                +`Maybe you meant "${maybe_suggestion}"`
+            );
+        else
+            throw new Sk.builtin.ValueError(
+                `keyname must be a valid key. ` 
+                + `You can use keys from "a" to "z", from "0" to "9", the space `
+                + `key: " ", or one of the following: "ArrowLeft", "ArrowDown", `
+                + `"ArrowUp", "ArrowRight".`
+            );
+    }
+
     const new_pytch_suspension = (syscall_name, syscall_args) => {
         let susp = new Sk.misceval.Suspension();
 

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -22,9 +22,7 @@ var $builtinmodule = function (name) {
     }
 
     mod._assert_keyname_valid = skulpt_function(
-        (keyname) => {
-            assertPyKeynameValid(keyname);
-        },
+        assertPyKeynameValid,
         `(KEY_NAME) throws error if keyname is not valid; continue otherwise`,
     );
 

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -15,6 +15,8 @@ var $builtinmodule = function (name) {
             map[validKey.toLowerCase()] = validKey;
     });
 
+    const isValidKeyname = (keyname) => validKeys.includes(keyname)
+
     const new_pytch_suspension = (syscall_name, syscall_args) => {
         let susp = new Sk.misceval.Suspension();
 

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -23,7 +23,7 @@ var $builtinmodule = function (name) {
 
     mod._assert_keyname_valid = skulpt_function(
         assertPyKeynameValid,
-        `(KEY_NAME) throws error if keyname is not valid; continue otherwise`,
+        `(KEYNAME) Throw error if keyname not valid; otherwise continue`,
     );
 
     function assertPyKeynameValid(py_keyname) {

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -36,7 +36,7 @@ var $builtinmodule = function (name) {
             return;
         if (!jsKeyname)
             throw new Sk.builtin.ValueError(
-                `keyname must not be an empty string.`
+                `keyname must not be an empty string`
             );
         if (!jsKeyname.trim())
             throw new Sk.builtin.ValueError(
@@ -47,14 +47,14 @@ var $builtinmodule = function (name) {
         const maybe_suggestion = suggestedKeyname(jsKeyname)
         if (maybe_suggestion != null)
             throw new Sk.builtin.ValueError(
-                `keyname must be a valid key. `
-                +`Maybe you meant "${maybe_suggestion}"`
+                `keyname must be a valid key; `
+                +`did you mean "${maybe_suggestion}"?`
             );
         throw new Sk.builtin.ValueError(
-            `keyname must be a valid key. ` 
-            + `You can use keys from "a" to "z", from "0" to "9", the space `
+            `keyname must be a valid key; ` 
+            + `you can use keys from "a" to "z", from "0" to "9", the space `
             + `key: " ", or one of the following: "ArrowLeft", "ArrowDown", `
-            + `"ArrowUp", "ArrowRight".`
+            + `"ArrowUp", "ArrowRight"`
         );
     }
 

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -21,11 +21,6 @@ var $builtinmodule = function (name) {
         return suggested_key || null;
     }
 
-    mod._assert_keyname_valid = skulpt_function(
-        assertPyKeynameValid,
-        `(KEYNAME) Throw error if keyname not valid; otherwise continue`,
-    );
-
     function assertPyKeynameValid(py_keyname) {
         if (!Sk.builtin.checkString(py_keyname))
             throw new Sk.builtin.ValueError(
@@ -57,6 +52,11 @@ var $builtinmodule = function (name) {
             + `"ArrowUp", "ArrowRight"`
         );
     }
+
+    mod._assert_keyname_valid = skulpt_function(
+        assertPyKeynameValid,
+        `(KEYNAME) Throw error if keyname not valid; otherwise continue`,
+    );
 
     const new_pytch_suspension = (syscall_name, syscall_args) => {
         let susp = new Sk.misceval.Suspension();

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -17,6 +17,15 @@ var $builtinmodule = function (name) {
 
     const isValidKeyname = (keyname) => validKeys.includes(keyname)
 
+    function suggestedKeyname(invalidKeyname) {
+        //Remove symbols and capital letters to suggest a keyname
+        //Eg "Arrowleft", "arrowLeft" or "Arrow-Left" -> "ArrowLeft"
+        const invalidKeynameLower = invalidKeyname.toLowerCase();
+        var invalidKeynameCleaned = invalidKeynameLower.trim().replace(/[^a-z0-9]/g, "");
+        const suggested_key = map[invalidKeynameCleaned];
+        return suggested_key || null;
+    }
+
     const new_pytch_suspension = (syscall_name, syscall_args) => {
         let susp = new Sk.misceval.Suspension();
 

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -8,6 +8,13 @@ var $builtinmodule = function (name) {
     "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
     " ", "ArrowLeft", "ArrowDown", "ArrowUp", "ArrowRight"];
 
+    const map = {};
+
+    validKeys.forEach(validKey => {
+        if (validKey !== " ")
+            map[validKey.toLowerCase()] = validKey;
+    });
+
     const new_pytch_suspension = (syscall_name, syscall_args) => {
         let susp = new Sk.misceval.Suspension();
 

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -26,6 +26,13 @@ var $builtinmodule = function (name) {
         return suggested_key || null;
     }
 
+    mod._assert_keyname_valid = skulpt_function(
+        (keyname) => {
+            assertPyKeynameValid(keyname);
+        },
+        `(KEY_NAME) throws error if keyname is not valid; continue otherwise`,
+    );
+
     function assertPyKeynameValid(py_keyname) {
         if (!Sk.builtin.checkString(py_keyname))
             throw new Sk.builtin.ValueError(

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -3,6 +3,11 @@ var $builtinmodule = function (name) {
 
     const skulpt_function = Sk.pytchsupport.skulpt_function;
 
+    const validKeys = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", 
+    "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z", 
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
+    " ", "ArrowLeft", "ArrowDown", "ArrowUp", "ArrowRight"];
+
     const new_pytch_suspension = (syscall_name, syscall_args) => {
         let susp = new Sk.misceval.Suspension();
 

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -52,13 +52,12 @@ var $builtinmodule = function (name) {
                 `keyname must be a valid key. `
                 +`Maybe you meant "${maybe_suggestion}"`
             );
-        else
-            throw new Sk.builtin.ValueError(
-                `keyname must be a valid key. ` 
-                + `You can use keys from "a" to "z", from "0" to "9", the space `
-                + `key: " ", or one of the following: "ArrowLeft", "ArrowDown", `
-                + `"ArrowUp", "ArrowRight".`
-            );
+        throw new Sk.builtin.ValueError(
+            `keyname must be a valid key. ` 
+            + `You can use keys from "a" to "z", from "0" to "9", the space `
+            + `key: " ", or one of the following: "ArrowLeft", "ArrowDown", `
+            + `"ArrowUp", "ArrowRight".`
+        );
     }
 
     const new_pytch_suspension = (syscall_name, syscall_args) => {

--- a/src/lib/pytch/syscalls.js
+++ b/src/lib/pytch/syscalls.js
@@ -16,7 +16,7 @@ var $builtinmodule = function (name) {
         //Remove symbols and capital letters to suggest a keyname
         //Eg "Arrowleft", "arrowLeft" or "Arrow-Left" -> "ArrowLeft"
         const invalidKeynameLower = invalidKeyname.toLowerCase();
-        var invalidKeynameCleaned = invalidKeynameLower.trim().replace(/[^a-z0-9]/g, "");
+        const invalidKeynameCleaned = invalidKeynameLower.replace(/[^a-z0-9]/g, "");
         const suggested_key = validKeyFromLowerCaseLut.get(invalidKeynameCleaned);
         return suggested_key || null;
     }

--- a/test/pytch/test_build_errors.js
+++ b/test/pytch/test_build_errors.js
@@ -145,4 +145,77 @@ describe("build-error handling", () => {
             )
         );
     });
+
+    [
+        {
+            label: "empty-string",
+            arg: '""',
+            error_regexp: /must not be an empty string/
+        },
+        { 
+            label: "capital-letter",
+            arg: '"W"',
+            error_regexp: /must be a valid key. Maybe you meant "w"/ 
+        },
+        {
+            label: "capital-letter",
+            arg: '" w "',
+            error_regexp: /must be a valid key. Maybe you meant "w"/
+        },
+        {
+            label: "capital-letter",
+            arg: '" w+ "',
+            error_regexp: /must be a valid key. Maybe you meant "w"/ },
+
+        {
+            label: "capital-letter",
+            arg: '" ArrowUp"',
+            error_regexp: /must be a valid key. Maybe you meant "ArrowUp"/
+        },
+        {
+            label: "capital-letter",
+            arg: '"arrowUp"',
+            error_regexp: /must be a valid key. Maybe you meant "ArrowUp"/ 
+        },
+        
+        {
+            label: "misspelled-key",
+            arg: '"arrow-up"',
+            error_regexp: /must be a valid key. Maybe you meant "ArrowUp"/ 
+        },
+        {
+            label: "misspelled-key",
+            arg: '"   "',
+            error_regexp: /must be a valid key; if you meant the spacebar, use " "/ },
+
+        {
+            label: "invalid-key",
+            arg: '"!"',
+            error_regexp: /must be a valid key. You can use keys/ 
+        },
+        {
+            label: "no-string",
+            arg: "1",
+            error_regexp: /must be a string/ 
+        },
+    ].forEach(spec => {
+        it(`rejects bad arg to when_key_pressed (${spec.label})`,
+        async () => {
+            const import_project = import_deindented(`
+                import pytch
+                @pytch.when_key_pressed(${spec.arg})
+                def invalid_hat():
+                    pass
+            `);
+
+            await assert.rejects(
+                import_project,
+                assertBuildErrorFun(
+                    "import",
+                    Sk.builtin.ValueError,
+                    spec.error_regexp
+                )
+            );
+        });
+    });
 });

--- a/test/pytch/test_build_errors.js
+++ b/test/pytch/test_build_errors.js
@@ -155,33 +155,33 @@ describe("build-error handling", () => {
         { 
             label: "capital-letter",
             arg: '"W"',
-            error_regexp: /must be a valid key. Maybe you meant "w"/ 
+            error_regexp: /must be a valid key; did you mean "w"/ 
         },
         {
             label: "capital-letter",
             arg: '" w "',
-            error_regexp: /must be a valid key. Maybe you meant "w"/
+            error_regexp: /must be a valid key; did you mean "w"/
         },
         {
             label: "capital-letter",
             arg: '" w+ "',
-            error_regexp: /must be a valid key. Maybe you meant "w"/ },
+            error_regexp: /must be a valid key; did you mean "w"/ },
 
         {
             label: "capital-letter",
             arg: '" ArrowUp"',
-            error_regexp: /must be a valid key. Maybe you meant "ArrowUp"/
+            error_regexp: /must be a valid key; did you mean "ArrowUp"/
         },
         {
             label: "capital-letter",
             arg: '"arrowUp"',
-            error_regexp: /must be a valid key. Maybe you meant "ArrowUp"/ 
+            error_regexp: /must be a valid key; did you mean "ArrowUp"/ 
         },
         
         {
             label: "misspelled-key",
             arg: '"arrow-up"',
-            error_regexp: /must be a valid key. Maybe you meant "ArrowUp"/ 
+            error_regexp: /must be a valid key; did you mean "ArrowUp"/ 
         },
         {
             label: "misspelled-key",
@@ -191,7 +191,7 @@ describe("build-error handling", () => {
         {
             label: "invalid-key",
             arg: '"!"',
-            error_regexp: /must be a valid key. You can use keys/ 
+            error_regexp: /must be a valid key; you can use keys/ 
         },
         {
             label: "no-string",

--- a/test/pytch/test_build_errors.js
+++ b/test/pytch/test_build_errors.js
@@ -158,22 +158,22 @@ describe("build-error handling", () => {
             error_regexp: /must be a valid key; did you mean "w"/ 
         },
         {
-            label: "capital-letter",
+            label: "misspelled-key",
             arg: '" w "',
             error_regexp: /must be a valid key; did you mean "w"/
         },
         {
-            label: "capital-letter",
+            label: "misspelled-key",
             arg: '" w+ "',
             error_regexp: /must be a valid key; did you mean "w"/ },
 
         {
-            label: "capital-letter",
+            label: "misspelled-key",
             arg: '" ArrowUp"',
             error_regexp: /must be a valid key; did you mean "ArrowUp"/
         },
         {
-            label: "capital-letter",
+            label: "misspelled-key",
             arg: '"arrowUp"',
             error_regexp: /must be a valid key; did you mean "ArrowUp"/ 
         },
@@ -199,7 +199,7 @@ describe("build-error handling", () => {
             error_regexp: /must be a string/ 
         },
     ].forEach(spec => {
-        it(`rejects bad arg to when_key_pressed (${spec.label})`,
+        it(`rejects bad arg to when_key_pressed(${spec.arg}) (${spec.label})`,
         async () => {
             const import_project = import_deindented(`
                 import pytch

--- a/test/pytch/test_hat_blocks.js
+++ b/test/pytch/test_hat_blocks.js
@@ -6,6 +6,9 @@ const {
     with_project,
     assert,
     py_getattr,
+    import_deindented,
+    one_frame,
+    mock_keyboard,
 } = require("./pytch-testing.js");
 configure_mocha();
 
@@ -83,4 +86,25 @@ describe("pytch.hat_blocks module", () => {
             assert.strictEqual(hello.n_events, 1);
             assert.ok(hello.includes("click", null));
         })});
+
+    const validKeysList = ["a", "z", "0", " ", "ArrowLeft", "ArrowDown", "ArrowUp", "ArrowRight"];
+    validKeysList.forEach(keyname => {
+        it(`key_pressed("${keyname}") accepted`,
+        async () => {
+            const import_project = await import_deindented(`
+                import pytch
+                class A_Sprite(pytch.Sprite):
+                    key_pressed = False         
+                    @pytch.when_key_pressed("${keyname}")
+                    def do_something(self):
+                        self.key_pressed = pytch.key_pressed("${keyname}")
+            `);
+
+            mock_keyboard.press_key(keyname);
+            one_frame(import_project);
+            mock_keyboard.release_key(keyname);
+            assert.strictEqual(import_project.instance_0_by_class_name("A_Sprite").js_attr("key_pressed"), true);
+            
+        });
+    });
 });


### PR DESCRIPTION
Add a list of valid keys for key_pressed() and when_key_pressed(), raising errors for invalid/bad args.

The error message also suggest a valid key if it recognizes a similar key inserted by the user.
E.g. for "Arrowleft", "arrowLeft", "Arrow-Left" it suggests "ArrowLeft"  or for " a ", "A", "-a" it suggests "a".

validKeys = ["a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v", "w", "x", "y", "z",
"0", "1", "2", "3", "4", "5", "6", "7", "8", "9", 
" ", "ArrowLeft", "ArrowDown", "ArrowUp", "ArrowRight"];